### PR TITLE
hparams key now matched LLM name

### DIFF
--- a/llms/anthropic_model.py
+++ b/llms/anthropic_model.py
@@ -9,7 +9,7 @@ class AnthropicModel:
         self.api_key = config['llms']['anthropic']['api_key'].strip()
 
         self.hparams = config['hparams']
-        self.hparams.update(config['llms']['openai'].get('hparams') or {})
+        self.hparams.update(config['llms']['anthropic'].get('hparams') or {})
         
     def make_request(self, conversation, add_image=None, logit_bias=None, max_tokens=None):
         conversation = [{"role": "user" if i%2 == 0 else "assistant", "content": content} for i,content in enumerate(conversation)]

--- a/llms/cohere_model.py
+++ b/llms/cohere_model.py
@@ -11,9 +11,8 @@ class CohereModel:
         api_key = config['llms']['cohere']['api_key'].strip()
         self.client = cohere.Client(api_key)
         self.name = name
-        config = json.load(open("config.json"))
         self.hparams = config['hparams']
-        self.hparams.update(config['llms']['openai'].get('hparams') or {})
+        self.hparams.update(config['llms']['cohere'].get('hparams') or {})
 
     def make_request(self, conversation, add_image=None, max_tokens=None):
         prior_messages = [{"role": "USER" if i%2 == 0 else "CHATBOT", "message": content} for i,content in enumerate(conversation[:-1])]

--- a/llms/moonshot_model.py
+++ b/llms/moonshot_model.py
@@ -11,9 +11,8 @@ class MoonshotAIModel:
         api_key = config['llms']['moonshot']['api_key'].strip()
         self.client = OpenAI(api_key=api_key, base_url='https://api.moonshot.cn/v1')
         self.name = name
-        config = json.load(open("config.json"))
         self.hparams = config['hparams']
-        self.hparams.update(config['llms']['openai'].get('hparams') or {})
+        self.hparams.update(config['llms']['moonshot'].get('hparams') or {})
 
     def make_request(self, conversation, add_image=None, max_tokens=None):
         conversation = [{"role": "user" if i%2 == 0 else "assistant", "content": content} for i,content in enumerate(conversation)]

--- a/llms/openai_model.py
+++ b/llms/openai_model.py
@@ -11,7 +11,6 @@ class OpenAIModel:
         api_key = config['llms']['openai']['api_key'].strip()
         self.client = OpenAI(api_key=api_key)
         self.name = name
-        config = json.load(open("config.json"))
         self.hparams = config['hparams']
         self.hparams.update(config['llms']['openai'].get('hparams') or {})
 

--- a/llms/vertexai_model.py
+++ b/llms/vertexai_model.py
@@ -11,7 +11,7 @@ class VertexAIModel:
         self.name = name
         config = json.load(open("config.json"))
         self.hparams = config['hparams']
-        self.hparams.update(config['llms']['mistral'].get('hparams') or {})
+        self.hparams.update(config['llms']['vertexai'].get('hparams') or {})
 
         self.name = name
 

--- a/llms/vertexai_model.py
+++ b/llms/vertexai_model.py
@@ -13,8 +13,6 @@ class VertexAIModel:
         self.hparams = config['hparams']
         self.hparams.update(config['llms']['vertexai'].get('hparams') or {})
 
-        self.name = name
-
         project_id = config['llms']['vertexai']['project_id'].strip()
         vertexai.init(project=project_id, location="us-central1")
 


### PR DESCRIPTION
I noticed that the hparams in the config file that were being accessed had copy-pasted code that had the wrong llm name. Updated to the right name according to class object.

While I don't know if this is an issue for your tests, as I don't have access to your config file, I imagine it could be a problem.