### PR TITLE
Enable support for Groq models

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -21,6 +21,9 @@
         },
         "moonshot": {
             "api_key": "TODO"
-        }        
+        },
+        "groq": {
+            "api_key": "TODO"
+        }
     }
 }

--- a/llm.py
+++ b/llm.py
@@ -27,6 +27,7 @@ from llms.mistral_model import MistralModel
 from llms.vertexai_model import VertexAIModel
 from llms.cohere_model import CohereModel
 from llms.moonshot_model import MoonshotAIModel
+from  llms.groq_model import GroqModel
 
 class LLM:
     def __init__(self, name="gpt-3.5-turbo", use_cache=True, override_hparams={}):
@@ -47,6 +48,8 @@ class LLM:
             self.model = MoonshotAIModel(name)            
         elif 'command' in name:
             self.model = CohereModel(name)
+        elif 'llama3' in name or 'mixtral' in name or 'gemma' in name:
+            self.model = GroqModel(name)
         else:
             raise
         self.model.hparams.update(override_hparams)

--- a/llms/groq_model.py
+++ b/llms/groq_model.py
@@ -1,0 +1,29 @@
+import groq
+import json
+
+class GroqModel:
+    def __init__(self, name):
+        self.name = name
+
+        config = json.load(open("config.json"))
+        self.api_key = config['llms']['groq']['api_key'].strip()
+
+        self.hparams = config['hparams']
+        self.hparams.update(config['llms']['groq'].get('hparams') or {})
+        
+    def make_request(self, conversation, add_image=None, logit_bias=None, max_tokens=None):
+        conversation = [{"role": "user" if i%2 == 0 else "assistant", "content": content} for i,content in enumerate(conversation)]
+        response = groq.Groq(api_key=self.api_key).chat.completions.create(
+            model=self.name,
+            max_tokens=2048,
+            messages=conversation
+        )
+
+        return response.choices[0].message.content
+
+
+if __name__ == "__main__":
+    import sys
+    q = "What's your name?"
+    print(q+":", GroqModel("llama3-70b-8192").make_request([q]))
+

--- a/requirements-extra.txt
+++ b/requirements-extra.txt
@@ -3,3 +3,4 @@ anthropic
 google-cloud-aiplatform
 cohere
 google-generativeai
+groq


### PR DESCRIPTION
I added support for Groq models.
I benchmarked the Llama 3 models (using gpt-3-5-turbo as evaluator) with the following results.
![image](https://github.com/carlini/yet-another-applied-llm-benchmark/assets/69345428/cf0d949f-d663-4dc9-b3a8-d3b7cc2c3e51)
